### PR TITLE
Okta compatibility updates

### DIFF
--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -9,6 +9,7 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
         client_secret: System.get_env("OKTA_CLIENT_SECRET")
   You can also include options from the `OAuth2.Client` struct which will take precedence.
   """
+  require Jason
   use OAuth2.Strategy
 
   alias OAuth2.{Client, Strategy.AuthCode}
@@ -41,6 +42,7 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
                   |> Keyword.merge(config)
 
     Client.new(client_opts)
+    |> OAuth2.Client.put_serializer("application/json", Jason)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Ueberauth.Okta.Mixfile do
 
   defp deps do
     [
-     {:oauth2, git: "git@github.com:Deconstrained/oauth2"},
+     {:oauth2, "~> 2.0"},
      {:ueberauth, "~> 0.6"},
 
      # dev/test only dependencies

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,7 @@ defmodule Ueberauth.Okta.Mixfile do
 
   defp deps do
     [
+     {:jason, "~> 1.2"},
      {:oauth2, "~> 2.0"},
      {:ueberauth, "~> 0.6"},
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,8 @@ defmodule Ueberauth.Okta.Mixfile do
 
   defp deps do
     [
-     {:oauth2, "~> 0.9"},
-     {:ueberauth, "~> 0.4"},
+     {:oauth2, "~> 2.0"},
+     {:ueberauth, "~> 0.6"},
 
      # dev/test only dependencies
      {:credo, "~> 0.8", only: [:dev, :test]},

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Ueberauth.Okta.Mixfile do
 
   defp deps do
     [
-     {:oauth2, "~> 2.0"},
+     {:oauth2, git: "git@github.com:Deconstrained/oauth2"},
      {:ueberauth, "~> 0.6"},
 
      # dev/test only dependencies


### PR DESCRIPTION
Inconsistencies have been discovered between Okta's API and the OAuth2 implementation in this library that affect its ability to successfully get all the way through the authorization flow.

These issues, which are addressed in this change set, are as follows:

* The client credentials are included in both the body (`params`) and in the basic authorization header; Okta will issue a 403 in response to this.
* Okta's response containing the access token is JSON-encoded, and since `oauth2` does not by default support the JSON mimetype, the JSON string containing the token is treated as the token itself, which results in a 401 when making the final request to authenticate the user back to Okta.