### PR TITLE
Fix compile warning

### DIFF
--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -86,7 +86,7 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
   end
 
   defp validate_code(client, params) do
-    {code, params} = Keyword.pop(params, :code, client.params["code"])
+    code = Keyword.get(params, :code, client.params["code"])
     unless code do
       raise OAuth2.Error, reason: "Missing required key `code` for `#{inspect(__MODULE__)}`"
     end


### PR DESCRIPTION
```
==> ueberauth_okta
Compiling 3 files (.ex)
warning: variable "params" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/ueberauth/strategy/okta/oauth.ex:89: Ueberauth.Strategy.Okta.OAuth.validate_code/2
```