### PR TITLE
Allow dynamic configs

### DIFF
--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -40,9 +40,10 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
   Ueberauth.
   """
   def client(opts \\ []) do
+    config = Keyword.take(opts, [:client_id, :client_secret, :site])
+    config = if config != [], do: config, else: Application.fetch_env!(:ueberauth, __MODULE__)
 
-    config = :ueberauth
-             |> Application.fetch_env!(__MODULE__)
+    config = config
              |> validate_config_option!(:client_id)
              |> validate_config_option!(:client_secret)
              |> validate_config_option!(:site)
@@ -65,7 +66,9 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
   end
 
   def get_user_info(token, headers \\ [], opts \\ []) do
-    [token: token]
+    opts = Keyword.merge(opts, token: token)
+
+    opts
     |> client()
     |> Client.get(userinfo_url(), headers, opts)
   end

--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -41,25 +41,14 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
   """
   def client(opts \\ []) do
     config = Application.fetch_env!(:ueberauth, __MODULE__)
-      @defaults
-      |> Keyword.merge(config)
-      |> Keyword.merge(opts)
-      |> validate_config_option!(:client_id)
-      |> validate_config_option!(:client_secret)
-      |> validate_config_option!(:site)
-      |> Client.new()
-      |> OAuth2.Client.put_serializer("application/json", Jason)
 
-    config = config
-             |> validate_config_option!(:client_id)
-             |> validate_config_option!(:client_secret)
-             |> validate_config_option!(:site)
-
-    client_opts = @defaults
-                  |> Keyword.merge(opts)
-                  |> Keyword.merge(config)
-
-    Client.new(client_opts)
+    @defaults
+    |> Keyword.merge(config)
+    |> Keyword.merge(opts)
+    |> validate_config_option!(:client_id)
+    |> validate_config_option!(:client_secret)
+    |> validate_config_option!(:site)
+    |> Client.new()
     |> OAuth2.Client.put_serializer("application/json", Jason)
   end
 

--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -40,8 +40,15 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
   Ueberauth.
   """
   def client(opts \\ []) do
-    config = Keyword.take(opts, [:client_id, :client_secret, :site])
-    config = if config != [], do: config, else: Application.fetch_env!(:ueberauth, __MODULE__)
+    config = Application.fetch_env!(:ueberauth, __MODULE__)
+      @defaults
+      |> Keyword.merge(config)
+      |> Keyword.merge(opts)
+      |> validate_config_option!(:client_id)
+      |> validate_config_option!(:client_secret)
+      |> validate_config_option!(:site)
+      |> Client.new()
+      |> OAuth2.Client.put_serializer("application/json", Jason)
 
     config = config
              |> validate_config_option!(:client_id)


### PR DESCRIPTION
Hey @jjcarstens, 

I propose the following PR to allow `UeberauthOkta` to be used with multi-tenant applications (where a single Okta config won't be sufficient; i.e. applications that let users to login via their own Okta accounts). 

It somehow relates to this comment [here](https://github.com/ueberauth/ueberauth/issues/106#issuecomment-618062131) and this one [here](https://github.com/ueberauth/ueberauth/issues/106#issuecomment-631787288).

Basically what I'm doing is passing a bunch of options from the conn all the way down to the `Oauth.client/1` function. This way, I can do the following in my app controller:

```elixir
  def request(conn, %{"provider" => "okta", "key" => key}) do
    config = configure(key)
    config = Application.fetch_env!(:ueberauth, Ueberauth.Strategy.Okta.OAuth)[key]

    Ueberauth.run_request(conn, "okta", {
      Ueberauth.Strategy.Okta,
      [
        client_id: config[:client_id],
        client_secret: config[:client_secret],
        site: config[:site],
        callback_path: "/auth/okta/callback/#{key}",
        default_scope: "user",
        request_path: config[:site]
      ]
    })
  end
```

You can see here that I select the proper Okta credentials based on some path params. 
Let me know what you think. Happy to discuss a different approach. 