### PR TITLE
Use options from provider in Ueberauth.Strategy.Okta.OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ config :ueberauth, Ueberauth,
   ]
 ```
 
+If you have configured a custom Okta Authorization Server, you can specify it using the
+`authorization_server_id` key. This will cause request URLs to be adjusted to include the ID,
+saving you the effort of configuring the `authorization_url`, `token_url` etc... directly.
+
 You can also include options for the underlying OAuth strategy. If using the
 default (`Ueberauth.Strategy.Okta.OAuth`), then options for `OAuth2.Client.t()`
 are supported.

--- a/README.md
+++ b/README.md
@@ -26,27 +26,27 @@ def application do
 end
 ```
 
-Include the provider in your configuration for Ueberauth:
-
-```elixir
-config :ueberauth, Ueberauth,
-  providers: [
-    okta: { Ueberauth.Strategy.Okta, [] }
-  ]
-```
-
 You'll need to register a new application with Okta and get the `client_id` and `client_secret`. That setup is out of the scope of this library, but some notes to remember are:
   * Ensure `Authorization Code` grant type is enabled
   * You have valid `Login Redirect Urls` listed for the app that correctly reference your callback route(s)
   * `user` and/or `group` permissions may need to be added to your Okta app before successfully authenticating
 
-Then include the configuration for okta.
+Include these settings in your provider configuration for Ueberauth:
+
 ```elixir
-config :ueberauth, Ueberauth.Strategy.Okta.OAuth,
-  client_id: System.get_env("OKTA_CLIENT_ID"),
-  client_secret: System.get_env("OKTA_CLIENT_SECRET"),
-  site: "https://your-doman.okta.com"
+config :ueberauth, Ueberauth,
+  providers: [
+    okta: { Ueberauth.Strategy.Okta, [
+      client_id: System.get_env("OKTA_CLIENT_ID"),
+      client_secret: System.get_env("OKTA_CLIENT_SECRET"),
+      site: "https://your-doman.okta.com"
+    ] }
+  ]
 ```
+
+You can also include options for the underlying OAuth strategy. If using the
+default (`Ueberauth.Strategy.Okta.OAuth`), then options for `OAuth2.Client.t()`
+are supported.
 
 If you haven't already, create a pipeline and setup routes for your callback handler
 ```elixir

--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -94,6 +94,7 @@ defmodule Ueberauth.Strategy.Okta do
   @doc """
   Includes the credentials from the Okta response.
   """
+  @impl Ueberauth.Strategy
   def credentials(conn) do
     token = conn.private.okta_token
 
@@ -110,6 +111,7 @@ defmodule Ueberauth.Strategy.Okta do
   @doc """
   Stores the raw information (including the token) obtained from the Okta callback.
   """
+  @impl Ueberauth.Strategy
   def extra(conn) do
     %Extra {
       raw_info: %{
@@ -125,6 +127,7 @@ defmodule Ueberauth.Strategy.Okta do
   Supports `state` and `redirect_uri` params which are required for Okta /authorize request. These will also be generated if omitted.
   `redirect_uri` in Ueberauth.Strategy.Okta.OAuth config will take precedence over value provided here
   """
+  @impl Ueberauth.Strategy
   def handle_request!(conn) do
     redirect_uri = conn.params["redirect_uri"] || callback_url(conn)
     opts = Keyword.merge(conn.private.ueberauth_request_options.options, redirect_uri: redirect_uri)
@@ -144,6 +147,7 @@ defmodule Ueberauth.Strategy.Okta do
   When there is a failure from Okta the failure is included in the
   `ueberauth_failure` struct. Otherwise the information returned from Okta is returned in the `Ueberauth.Auth` struct.
   """
+  @impl Ueberauth.Strategy
   def handle_callback!(%Conn{params: %{"code" => code}} = conn) do
     module = option(conn, :oauth2_module)
     opts = Keyword.merge(conn.private.ueberauth_request_options.options, redirect_uri: callback_url(conn))
@@ -167,6 +171,7 @@ defmodule Ueberauth.Strategy.Okta do
   @doc """
   Cleans up the private area of the connection used for passing the raw Okta response around during the callback.
   """
+  @impl Ueberauth.Strategy
   def handle_cleanup!(conn) do
     conn
     |> put_private(:okta_user, nil)
@@ -176,6 +181,7 @@ defmodule Ueberauth.Strategy.Okta do
   @doc """
   Fetches the fields to populate the info section of the `Ueberauth.Auth` struct.
   """
+  @impl Ueberauth.Strategy
   def info(conn) do
     user = conn.private.okta_user
 
@@ -194,6 +200,7 @@ defmodule Ueberauth.Strategy.Okta do
   @doc """
   Fetches the uid field from the Okta response. This defaults to the option `uid_field` which in-turn defaults to `sub`
   """
+  @impl Ueberauth.Strategy
   def uid(conn) do
     conn
     |> option(:uid_field)

--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -141,8 +141,7 @@ defmodule Ueberauth.Strategy.Okta do
   """
   @impl Ueberauth.Strategy
   def handle_request!(conn) do
-    redirect_uri = conn.params["redirect_uri"] || callback_url(conn)
-    opts = Keyword.merge(options(conn), redirect_uri: redirect_uri)
+    opts = Keyword.merge(options(conn), redirect_uri: callback_url(conn))
 
     params =
       conn

--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -28,6 +28,10 @@ defmodule Ueberauth.Strategy.Okta do
           ]}
         ]
 
+  If you have configured a custom Okta Authorization Server, you can specify it using the
+  `authorization_server_id` key. This will cause request URLs to be adjusted to include the ID,
+  saving you the effort of configuring the `authorization_url`, `token_url` etc... directly.
+
   You can also include options for the underlying OAuth strategy. If using the
   default (`Ueberauth.Strategy.Okta.OAuth`), then options for `OAuth2.Client.t()`
   are supported
@@ -225,13 +229,12 @@ defmodule Ueberauth.Strategy.Okta do
   defp fetch_user(conn, token) do
     conn = put_private(conn, :okta_token, token)
     module = option(conn, :oauth2_module)
-    userinfo_url = option(conn, :userinfo_url)
 
     opts =
       options(conn)
       |> Keyword.put(:token, token)
 
-    with {:ok, user} <- module.get_user_info(userinfo_url, _headers = [], opts) do
+    with {:ok, user} <- module.get_user_info(_headers = [], opts) do
       put_private(conn, :okta_user, user)
     else
       {:error, %OAuth2.Error{reason: reason}} ->

--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -57,6 +57,7 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
     |> validate_config_option!(:client_id)
     |> validate_config_option!(:client_secret)
     |> validate_config_option!(:site)
+    |> Keyword.put(:strategy, __MODULE__)
     |> Client.new()
     |> Client.put_serializer("application/json", Jason)
   end

--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -73,12 +73,14 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
 
   # Strategy Callbacks
 
+  @impl OAuth2.Strategy
   def authorize_url(client, params) do
     client
     |> put_param(:nonce, Base.encode16(:crypto.strong_rand_bytes(32)))
     |> AuthCode.authorize_url(params)
   end
 
+  @impl OAuth2.Strategy
   def get_token(client, params, headers) do
     client
     |> put_header("Accept", "application/json")


### PR DESCRIPTION
Fixes https://github.com/jjcarstens/ueberauth_okta/issues/10

This is a breaking change that removes the ability to set OAuth settings in the application environment and instead relies on the settings coming in from the Ueberauth provider setup.

This fixes the ability to use multiple providers with this library

/cc @giddie