### PR TITLE
Set missing strategy key for OAuth2 client

### DIFF
--- a/lib/ueberauth/strategy/okta/oauth.ex
+++ b/lib/ueberauth/strategy/okta/oauth.ex
@@ -55,6 +55,7 @@ defmodule Ueberauth.Strategy.Okta.OAuth do
     |> validate_config_option!(:client_id)
     |> validate_config_option!(:client_secret)
     |> validate_config_option!(:site)
+    |> Keyword.put(:strategy, __MODULE__)
     |> Client.new()
     |> Client.put_serializer("application/json", Jason)
   end


### PR DESCRIPTION
This key was lost when the `@defaults` key was removed, and is required to complete the token request.