### PR TITLE
Ensure same redirect_uri for request and callback

### DIFF
--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -137,8 +137,7 @@ defmodule Ueberauth.Strategy.Okta do
   """
   @impl Ueberauth.Strategy
   def handle_request!(conn) do
-    redirect_uri = conn.params["redirect_uri"] || callback_url(conn)
-    opts = Keyword.merge(options(conn), redirect_uri: redirect_uri)
+    opts = Keyword.merge(options(conn), redirect_uri: callback_url(conn))
 
     params =
       conn


### PR DESCRIPTION
**NOTE:** This uses the **multiple-providers** branch as a base, assuming it'll be merged soon.

Previously, we would pick up the `redirect_uri` from `conn.params`, but nothing is done to ensure the same value is used in `handle_callback!`. The reference Google stratery from the ueberauth team appears to rely only on `callback_url(conn)`, which seems more sensible here.