### PR TITLE
Include options collected by the Helpers.options helper

### DIFF
--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -201,7 +201,15 @@ defmodule Ueberauth.Strategy.Okta do
 
   defp add_oauth_options(opts, conn) do
     oauth_opts = Application.get_env(:ueberauth, Ueberauth.Strategy.Okta.OAuth, [])
-    oauth_opts = oauth_opts[strategy_name(conn)] || oauth_opts
+
+    multitenant_key =
+      try do
+        conn |> strategy_name() |> String.to_existing_atom()
+      rescue
+        ArgumentError -> nil
+      end
+
+    oauth_opts = oauth_opts[multitenant_key] || oauth_opts
     Keyword.merge(opts, oauth_opts)
   end
 end


### PR DESCRIPTION
The 1.0.0 -> 1.1.0 upgrade broke the ability to use provider options passed directly into [run_request](https://hexdocs.pm/ueberauth/Ueberauth.html#run_request/4). The switch to `Keyword.get` is to prevent an issue in the Access module when the strategy name has no corresponding key in the opts list, which happens in my case (because I pass the options directly into `run_request`).

This PR merges these options in in addition to the existing options.