### PR TITLE
Fix option merging when provider is a string

### DIFF
--- a/lib/ueberauth/strategy/okta.ex
+++ b/lib/ueberauth/strategy/okta.ex
@@ -201,7 +201,19 @@ defmodule Ueberauth.Strategy.Okta do
 
   defp add_oauth_options(opts, conn) do
     oauth_opts = Application.get_env(:ueberauth, Ueberauth.Strategy.Okta.OAuth, [])
-    oauth_opts = oauth_opts[strategy_name(conn)] || oauth_opts
-    Keyword.merge(opts, oauth_opts)
+
+    # The Ueberauth helper function says strategy_name, but this is the provider
+    # name used from the Application config
+    provider = strategy_name(conn)
+    provider_str = to_string(provider)
+
+    provider_opts =
+      Enum.find_value(oauth_opts, oauth_opts, fn
+        {^provider, v} -> v
+        {^provider_str, v} -> v
+        _ -> false
+      end)
+
+    Keyword.merge(opts, provider_opts)
   end
 end


### PR DESCRIPTION
This is the result of @giddie discovery and work in #18

In some cases, the incoming provider name may be a string (like when using `run_request` directly) instead of an atom, as typically seen in the docs. In those cases, this fails to get the provider options that may be in the config.

This fixes the lookup to be indifferent by forcing both keys to be strings when comparing